### PR TITLE
Added file generators for creating a new component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+Style/Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false

--- a/lib/rails/generators/atomic_assets/component/component_generator.rb
+++ b/lib/rails/generators/atomic_assets/component/component_generator.rb
@@ -1,0 +1,38 @@
+module AtomicAssets
+  module Generators
+    class ComponentGenerator < Rails::Generators::Base
+      argument :component_name, required: true
+
+      desc <<-DESC.strip_heredoc
+        Creates all files requred when generating a new atomic asset component
+      DESC
+
+      source_root File.expand_path("../../templates", __FILE__)
+
+      def create_component_file
+        @component_name = class_prefix
+        template "component.rb", "app/components/#{file_prefix}_component.rb"
+      end
+
+      def create_scss_file
+        fullpath = "app/assets/stylesheets/components/_#{file_prefix}.scss"
+        template "component.scss", fullpath
+      end
+
+      def create_slim_file
+        fullpath = "app/views/components/#{file_prefix}.html.slim"
+        template "component.slim", fullpath
+      end
+
+      private
+
+      def file_prefix
+        component_name.underscore
+      end
+
+      def class_prefix
+        component_name.camelize
+      end
+    end
+  end
+end

--- a/lib/rails/generators/atomic_assets/templates/component.rb
+++ b/lib/rails/generators/atomic_assets/templates/component.rb
@@ -1,0 +1,24 @@
+class <%= component_name %>Component < AtomicAssets::Component
+  def edit
+    rtn = cms_fields(field_types)
+    rtn << h.component(:text_block, field_previews).render
+    rtn.html_safe
+  end
+
+  protected
+
+  def field_previews
+    {
+      header: "{{preview.header}}",
+      content: markdown_preview('preview.content')
+    }
+  end
+
+  def field_types
+    {
+      header: { field_type: "text" },
+      content: { field_type: "markdown" }
+    }
+  end
+end
+

--- a/lib/rails/generators/atomic_assets/templates/component.slim
+++ b/lib/rails/generators/atomic_assets/templates/component.slim
@@ -1,0 +1,4 @@
+// boilerplate slim file, replace these with the parameters you actually plan on
+// using
+h2= options[:header] if add_option(options[:header])
+= markdown(options[:content])


### PR DESCRIPTION
Why?
We need a quick way to frame out all the files needed for adding atomic
assets

How?
Added a rails specific generator for inserting the required files into
a rails project. AtomicAssets::Generators::ComponentGenerator. It adds
the following files to a project:
* component.rb
* component.html.slim
* component.scss

It can be called by the folling commmand:
rails generate atomic_assets:componenet COMPONENT_NAME

Side Effects?
Files are generated with sane defaults