### PR TITLE
Bugfix: generator component key reference

### DIFF
--- a/lib/rails/generators/atomic_assets/component/component_generator.rb
+++ b/lib/rails/generators/atomic_assets/component/component_generator.rb
@@ -10,7 +10,10 @@ module AtomicAssets
       source_root File.expand_path("../../templates", __FILE__)
 
       def create_component_file
-        @component_name = class_prefix
+        @component = OpenStruct.new(
+          class_prefix: class_prefix,
+          key: file_prefix
+        )
         template "component.rb", "app/components/#{file_prefix}_component.rb"
       end
 

--- a/lib/rails/generators/atomic_assets/templates/component.rb
+++ b/lib/rails/generators/atomic_assets/templates/component.rb
@@ -1,7 +1,7 @@
-class <%= component_name %>Component < AtomicAssets::Component
+class <%= @component.component_name %>Component < AtomicAssets::Component
   def edit
     rtn = cms_fields(field_types)
-    rtn << h.component(:text_block, field_previews).render
+    rtn << h.component(<%= ":#{@component.key}" %>), field_previews).render
     rtn.html_safe
   end
 


### PR DESCRIPTION
_Why?_

When creating a component using the generator, the key to reference the
component was locked to be :text_block. This was a result of a careless
copy and paste. My bad... :(

_How?_

Updated the component template to manually write a key from the snake
cased name of the component.

_Side Effects?_

Hopefully, components created with the generator will be effective and
self documenting.